### PR TITLE
Add embedding method

### DIFF
--- a/lib/hugging_face/base_api.rb
+++ b/lib/hugging_face/base_api.rb
@@ -15,7 +15,7 @@ module HuggingFace
 
     private
 
-    def connection(url)
+    def build_connection(url)
       Faraday.new(url, headers: @headers)
     end
 

--- a/spec/hugging_face/inference_api_spec.rb
+++ b/spec/hugging_face/inference_api_spec.rb
@@ -103,4 +103,23 @@ RSpec.describe HuggingFace::InferenceApi do
       it { is_expected.to eq([{ 'generated_text' => 'Generate next word for me' }]) }
     end
   end
+
+  describe '#embedding' do
+    let(:text)  { 'Generate an embedding' }
+    let(:input) { { inputs: text } }
+    let(:output) do
+      [[0.05994785204529762,
+        0.10895846039056778,
+        0.03463876247406006,]
+      ].to_json
+    end
+
+    context 'with default provided'  do
+      let(:url) { "https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2" }
+
+      subject { api.embedding(input: text) }
+
+      it { is_expected.to eq([[0.05994785204529762, 0.10895846039056778,0.03463876247406006]]) }
+    end
+  end
 end


### PR DESCRIPTION
Add embedding method to the client by calling `https://api-inference.huggingface.co/pipeline/feature-extraction/{model_id}` endpoint and `sentence-transformers/all-MiniLM-L6-v2` model