### PR TITLE
moves the MAX_RETRY constant to BaseApi

### DIFF
--- a/lib/hugging_face/base_api.rb
+++ b/lib/hugging_face/base_api.rb
@@ -7,6 +7,9 @@ module HuggingFace
     HTTP_SERVICE_UNAVAILABLE = 503
     JSON_CONTENT_TYPE = 'application/json'
 
+    # Retry connecting to the model for 1 minute
+    MAX_RETRY = 60
+
     def initialize(api_token:)
       @headers = {
         'Authorization' => 'Bearer ' + api_token,

--- a/lib/hugging_face/inference_api.rb
+++ b/lib/hugging_face/inference_api.rb
@@ -2,9 +2,6 @@ module HuggingFace
   class InferenceApi < BaseApi
     HOST = "https://api-inference.huggingface.co"
 
-    # Retry connecting to the model for 1 minute
-    MAX_RETRY = 60
-
     # Default models that can be overriden by 'model' param
     QUESTION_ANSWERING_MODEL = 'distilbert-base-cased-distilled-squad'
     SUMMARIZATION_MODEL = "sshleifer/distilbart-xsum-12-6"


### PR DESCRIPTION
The MAX_RETRY constant is used in both InferenceApi and EndpointsApi, but it is only declared in the InferenceApi. Moving it to the BaseApi, which both classes inherit from, solves this error:

`uninitialized constant HuggingFace::EndpointsApi::MAX_RETRY (NameError)`